### PR TITLE
[feat] Member API 생성 (인증/인가 및 이미지 처리 제외)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation "org.springframework.boot:spring-boot-starter-security"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/ApiResponse.java
@@ -1,0 +1,14 @@
+package kakao_tech_bootcamp.community.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private String message;
+    private T data;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
@@ -30,16 +30,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = ForbiddenException.class)
     public ResponseEntity<ApiResponse> forbiddenException(ForbiddenException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("not_authorized", e.getMessage()));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ApiResponse<>("not_authorized", e.getMessage()));
     }
 
     @ExceptionHandler(value = NotFoundException.class)
     public ResponseEntity<ApiResponse> notFoundException(NotFoundException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("not_found", e.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse<>("not_found", e.getMessage()));
     }
 
     @ExceptionHandler(value = ConflictException.class)
     public ResponseEntity<ApiResponse> conflictException(ConflictException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("conflict_request", e.getMessage()));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ApiResponse<>("conflict_request", e.getMessage()));
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package kakao_tech_bootcamp.community.common;
+
+import kakao_tech_bootcamp.community.common.exceptions.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.naming.ConfigurationException;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<String> errors = e.getFieldErrors().stream().map(fieldError -> fieldError.getDefaultMessage()).toList();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("invalid_request", errors));
+    }
+
+    @ExceptionHandler(value = BadRequestException.class)
+    public ResponseEntity<ApiResponse> badRequestException(BadRequestException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("invalid_request", e.getMessage()));
+    }
+
+    @ExceptionHandler(value = UnauthorizedException.class)
+    public ResponseEntity<ApiResponse> unauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse<>("not_authenticated", e.getMessage()));
+    }
+
+    @ExceptionHandler(value = ForbiddenException.class)
+    public ResponseEntity<ApiResponse> forbiddenException(ForbiddenException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("not_authorized", e.getMessage()));
+    }
+
+    @ExceptionHandler(value = NotFoundException.class)
+    public ResponseEntity<ApiResponse> notFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("not_found", e.getMessage()));
+    }
+
+    @ExceptionHandler(value = ConflictException.class)
+    public ResponseEntity<ApiResponse> conflictException(ConflictException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("conflict_request", e.getMessage()));
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
+++ b/src/main/java/kakao_tech_bootcamp/community/common/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import javax.naming.ConfigurationException;
 import java.util.List;
 
 @RestControllerAdvice

--- a/src/main/java/kakao_tech_bootcamp/community/config/SecurityConfig.java
+++ b/src/main/java/kakao_tech_bootcamp/community/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package kakao_tech_bootcamp.community.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())  // REST API 서버이므로 CSRF 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // TODO: 개발 편의상 모든 요청 허용. 추후 인증인가 기능 추가 필요
+                )
+                .httpBasic(basic -> basic.disable())  // REST API 서버임으로 HTTP Basic 비활성화
+                .build();
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -1,0 +1,59 @@
+package kakao_tech_bootcamp.community.controller;
+
+import kakao_tech_bootcamp.community.common.ApiResponse;
+import kakao_tech_bootcamp.community.dto.*;
+import kakao_tech_bootcamp.community.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/availability/email")
+    public ResponseEntity<ApiResponse> isAvailableEmail(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
+        memberService.existsEmail(memberAvailabilityDto);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
+    }
+
+    @PostMapping("/availability/nickname")
+    public ResponseEntity<ApiResponse> isAvailableNickname(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
+        memberService.existsNickname(memberAvailabilityDto);
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> saveMember(@RequestBody @Validated MemberCreateRequestDto memberCreateRequestDto) {
+        memberService.saveMember(memberCreateRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>("register_success", null));
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ApiResponse> findMember(@PathVariable Integer memberId) {
+        Map<String, MemberResponseDto> data = Map.of("member", memberService.findMember(memberId));
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", data));
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity modifyMember(@PathVariable Integer memberId, @RequestBody @Validated MemberUpdateRequestDto updateMemberRequestDto) {
+        memberService.modifyMember(memberId, updateMemberRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity removeMember(@PathVariable Integer memberId) {
+        memberService.removeMember(memberId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
+++ b/src/main/java/kakao_tech_bootcamp/community/controller/MemberController.java
@@ -23,13 +23,13 @@ public class MemberController {
 
     @PostMapping("/availability/email")
     public ResponseEntity<ApiResponse> isAvailableEmail(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
-        memberService.existsEmail(memberAvailabilityDto);
+        memberService.existsByEmail(memberAvailabilityDto);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
     }
 
     @PostMapping("/availability/nickname")
     public ResponseEntity<ApiResponse> isAvailableNickname(@RequestBody @Validated MemberAvailabilityDto memberAvailabilityDto) {
-        memberService.existsNickname(memberAvailabilityDto);
+        memberService.existsByNickname(memberAvailabilityDto);
         return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>("ok", null));
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberAvailabilityDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberAvailabilityDto.java
@@ -1,0 +1,16 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MemberAvailabilityDto {
+    @Email(message = "이메일 형식이 유효하지 않습니다")
+    @Size(max = 50, message = "이메일 형식이 유효하지 않습니다")
+    private String email;
+
+    @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")
+    private String nickname;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberCreateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberCreateRequestDto.java
@@ -1,0 +1,26 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import kakao_tech_bootcamp.community.entity.Image;
+import lombok.Getter;
+
+@Getter
+public class MemberCreateRequestDto {
+    @Email(message = "이메일 형식이 유효하지 않습니다")
+    @Size(max = 50, message = "이메일 형식이 유효하지 않습니다")
+    private String email;
+
+    @Pattern(regexp = "^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])(?=.*?[~.!@#$%^&*()_\\-+=\\[\\]{}|\\\\;:'\",?/]).{8,20}$", message = "비밀번호 형식이 유효하지 않습니다")
+    private String password;
+
+    @NotBlank(message = "비밀번호가 일치하지 않습니다")
+    private String confirmedPassword;
+
+    @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")
+    private String nickname;
+
+    private Image image;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberResponseDto.java
@@ -1,0 +1,18 @@
+package kakao_tech_bootcamp.community.dto;
+
+import kakao_tech_bootcamp.community.entity.Image;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@NoArgsConstructor
+public class MemberResponseDto {
+    private Integer id;
+    private String email;
+    private String nickname;
+    private Image image;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/kakao_tech_bootcamp/community/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package kakao_tech_bootcamp.community.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import kakao_tech_bootcamp.community.entity.Image;
+import lombok.Getter;
+
+@Getter
+public class MemberUpdateRequestDto {
+    @Pattern(regexp = "^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])(?=.*?[~.!@#$%^&*()_\\-+=\\[\\]{}|\\\\;:'\",?/]).{8,20}$", message = "비밀번호 형식이 유효하지 않습니다")
+    private String password;
+
+    @NotBlank(message = "비밀번호가 일치하지 않습니다")
+    private String confirmedPassword;
+
+    @Pattern(regexp = "^\\S{1,10}$", message = "닉네임 형식이 유효하지 않습니다")
+    private String nickname;
+
+    private Image image;
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
@@ -1,0 +1,39 @@
+package kakao_tech_bootcamp.community.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import kakao_tech_bootcamp.community.entity.Member;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MemberRepository {
+    @PersistenceContext
+    EntityManager em;
+
+    public boolean existsEmail(String email) {
+        Query query = em.createQuery("select count(m) from member m where m.email = :email")
+                .setParameter("email", email);
+        int count = (int) query.getSingleResult();
+        return count > 0;
+    }
+
+    public boolean existsNickname(String nickname) {
+        Query query = em.createQuery("select count(m) from member m where nickname = :nickname")
+                .setParameter("nickname", nickname);
+        int count = (int) query.getSingleResult();
+        return count > 0;
+    }
+
+    public void save(Member member) {
+        em.persist(member);
+    }
+
+    public Member findBy(Integer id) {
+        return em.find(Member.class, id);
+    }
+
+    public void remove(Member member) {
+        em.remove(member);
+    }
+}

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package kakao_tech_bootcamp.community.repository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import kakao_tech_bootcamp.community.entity.Member;
 import org.springframework.stereotype.Repository;
 
@@ -12,16 +13,16 @@ public class MemberRepository {
     EntityManager em;
 
     public boolean existsEmail(String email) {
-        Query query = em.createQuery("select count(m) from member m where m.email = :email")
-                .setParameter("email", email);
-        int count = (int) query.getSingleResult();
+        Long count= em.createQuery("select count(m) from Member m where m.email = :email", Long.class)
+                .setParameter("email", email)
+                .getSingleResult();
         return count > 0;
     }
 
     public boolean existsNickname(String nickname) {
-        Query query = em.createQuery("select count(m) from member m where nickname = :nickname")
-                .setParameter("nickname", nickname);
-        int count = (int) query.getSingleResult();
+        Long count = em.createQuery("select count(m) from Member m where nickname = :nickname", Long.class)
+                .setParameter("nickname", nickname)
+                .getSingleResult();
         return count > 0;
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
+++ b/src/main/java/kakao_tech_bootcamp/community/repository/MemberRepository.java
@@ -1,40 +1,12 @@
 package kakao_tech_bootcamp.community.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-import jakarta.persistence.Query;
-import jakarta.persistence.TypedQuery;
 import kakao_tech_bootcamp.community.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class MemberRepository {
-    @PersistenceContext
-    EntityManager em;
+public interface MemberRepository extends JpaRepository<Member, Integer> {
+    public boolean existsByEmail(String email);
 
-    public boolean existsEmail(String email) {
-        Long count= em.createQuery("select count(m) from Member m where m.email = :email", Long.class)
-                .setParameter("email", email)
-                .getSingleResult();
-        return count > 0;
-    }
-
-    public boolean existsNickname(String nickname) {
-        Long count = em.createQuery("select count(m) from Member m where nickname = :nickname", Long.class)
-                .setParameter("nickname", nickname)
-                .getSingleResult();
-        return count > 0;
-    }
-
-    public void save(Member member) {
-        em.persist(member);
-    }
-
-    public Member findBy(Integer id) {
-        return em.find(Member.class, id);
-    }
-
-    public void remove(Member member) {
-        em.remove(member);
-    }
+    public boolean existsByNickname(String nickname);
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -23,29 +23,31 @@ public class MemberService {
     }
 
     @Transactional
-    public void existsEmail(MemberAvailabilityDto memberAvailabilityDto) {
-        boolean exists = memberRepository.existsEmail(memberAvailabilityDto.getEmail());
-
-        if (exists) {
+    public void existsByEmail(MemberAvailabilityDto memberAvailabilityDto) {
+        if (memberRepository.existsByEmail(memberAvailabilityDto.getEmail())) {
             throw new ConflictException("중복된 이메일입니다");
         }
     }
 
     @Transactional
-    public void existsNickname(MemberAvailabilityDto memberAvailabilityDto) {
-        boolean exists = memberRepository.existsNickname(memberAvailabilityDto.getNickname());
-
-        if (exists) {
+    public void existsByNickname(MemberAvailabilityDto memberAvailabilityDto) {
+        if (memberRepository.existsByNickname(memberAvailabilityDto.getNickname())) {
             throw new ConflictException("중복된 닉네임입니다");
         }
     }
 
     @Transactional
     public void saveMember(MemberCreateRequestDto dto) {
-        if (dto.getPassword() != null) {
-            if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
-                throw new BadRequestException("비밀번호가 일치하지 않습니다");
-            }
+        if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
+            throw new BadRequestException("비밀번호가 일치하지 않습니다");
+        }
+
+        if (memberRepository.existsByEmail(dto.getEmail())) {
+            throw new ConflictException("중복된 이메일입니다");
+        }
+
+        if (memberRepository.existsByNickname(dto.getNickname())) {
+            throw new ConflictException("중복된 닉네임입니다");
         }
 
         // TODO: 비밀번호 암호화
@@ -56,11 +58,7 @@ public class MemberService {
 
     @Transactional
     public MemberResponseDto findMember(Integer id) {
-        Member member = memberRepository.findBy(id);
-
-        if (member == null) {
-            throw new NotFoundException("회원을 찾을 수 없습니다");
-        }
+        Member member = memberRepository.findById(id).orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
         MemberResponseDto memberResponseDto = new MemberResponseDto();
         memberResponseDto.setId(member.getId());
@@ -74,11 +72,8 @@ public class MemberService {
 
     @Transactional
     public void modifyMember(Integer id, MemberUpdateRequestDto dto) {
-        Member member = memberRepository.findBy(id);
-
-        if (member == null) {
-            throw new NotFoundException("회원을 찾을 수 없습니다");
-        }
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
 
         if (dto.getNickname() != null) {
             member.setNickname(dto.getNickname());
@@ -99,12 +94,8 @@ public class MemberService {
 
     @Transactional
     public void removeMember(Integer id) {
-        Member member = memberRepository.findBy(id);
-
-        if (member == null) {
-            throw new NotFoundException("회원을 찾을 수 없습니다");
-        }
-
-        memberRepository.remove(member);
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("회원을 찾을 수 없습니다"));
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -11,15 +11,18 @@ import kakao_tech_bootcamp.community.dto.MemberUpdateRequestDto;
 import kakao_tech_bootcamp.community.entity.Member;
 import kakao_tech_bootcamp.community.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public MemberService(MemberRepository memberRepository) {
+    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
         this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Transactional
@@ -50,9 +53,9 @@ public class MemberService {
             throw new ConflictException("중복된 닉네임입니다");
         }
 
-        // TODO: 비밀번호 암호화
+        String encoded = passwordEncoder.encode(dto.getPassword());
+        Member member = new Member(dto.getEmail(), encoded, dto.getNickname(), dto.getImage());
 
-        Member member = new Member(dto.getEmail(), dto.getPassword(), dto.getNickname(), dto.getImage());
         memberRepository.save(member);
     }
 

--- a/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
+++ b/src/main/java/kakao_tech_bootcamp/community/service/MemberService.java
@@ -1,0 +1,110 @@
+package kakao_tech_bootcamp.community.service;
+
+import jakarta.transaction.Transactional;
+import kakao_tech_bootcamp.community.common.exceptions.BadRequestException;
+import kakao_tech_bootcamp.community.common.exceptions.ConflictException;
+import kakao_tech_bootcamp.community.common.exceptions.NotFoundException;
+import kakao_tech_bootcamp.community.dto.MemberAvailabilityDto;
+import kakao_tech_bootcamp.community.dto.MemberCreateRequestDto;
+import kakao_tech_bootcamp.community.dto.MemberResponseDto;
+import kakao_tech_bootcamp.community.dto.MemberUpdateRequestDto;
+import kakao_tech_bootcamp.community.entity.Member;
+import kakao_tech_bootcamp.community.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void existsEmail(MemberAvailabilityDto memberAvailabilityDto) {
+        boolean exists = memberRepository.existsEmail(memberAvailabilityDto.getEmail());
+
+        if (exists) {
+            throw new ConflictException("중복된 이메일입니다");
+        }
+    }
+
+    @Transactional
+    public void existsNickname(MemberAvailabilityDto memberAvailabilityDto) {
+        boolean exists = memberRepository.existsNickname(memberAvailabilityDto.getNickname());
+
+        if (exists) {
+            throw new ConflictException("중복된 닉네임입니다");
+        }
+    }
+
+    @Transactional
+    public void saveMember(MemberCreateRequestDto dto) {
+        if (dto.getPassword() != null) {
+            if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
+                throw new BadRequestException("비밀번호가 일치하지 않습니다");
+            }
+        }
+
+        // TODO: 비밀번호 암호화
+
+        Member member = new Member(dto.getEmail(), dto.getPassword(), dto.getNickname(), dto.getImage());
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public MemberResponseDto findMember(Integer id) {
+        Member member = memberRepository.findBy(id);
+
+        if (member == null) {
+            throw new NotFoundException("회원을 찾을 수 없습니다");
+        }
+
+        MemberResponseDto memberResponseDto = new MemberResponseDto();
+        memberResponseDto.setId(member.getId());
+        memberResponseDto.setEmail(member.getEmail());
+        memberResponseDto.setNickname(member.getNickname());
+        memberResponseDto.setImage(member.getImage());
+        memberResponseDto.setCreatedAt(member.getCreatedAt());
+
+        return memberResponseDto;
+    }
+
+    @Transactional
+    public void modifyMember(Integer id, MemberUpdateRequestDto dto) {
+        Member member = memberRepository.findBy(id);
+
+        if (member == null) {
+            throw new NotFoundException("회원을 찾을 수 없습니다");
+        }
+
+        if (dto.getNickname() != null) {
+            member.setNickname(dto.getNickname());
+        }
+
+        if (dto.getPassword() != null) {
+            if (!dto.getPassword().equals(dto.getConfirmedPassword())) {
+                throw new BadRequestException("비밀번호가 일치하지 않습니다");
+            }
+
+            member.setPassword(dto.getPassword());
+        }
+
+        if (dto.getImage() != null) {
+            member.setImage(dto.getImage());
+        }
+    }
+
+    @Transactional
+    public void removeMember(Integer id) {
+        Member member = memberRepository.findBy(id);
+
+        if (member == null) {
+            throw new NotFoundException("회원을 찾을 수 없습니다");
+        }
+
+        memberRepository.remove(member);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- Member 엔티티 및 DTO 생성
    - 요청 DTO에 Validation 적용
- Member Controller, Service, Repository 작성
    - SpringSecurity의 PasswordEncoder로 비밀번호 암호화
- HTTP 예외 클래스 생성 및 GlobalExceptionHandler 적용


## 고민 내용

### 이메일/닉네임 중복 체크와 실제 회원가입 요청 사이에 다른 사용자에 의해 똑같은 이메일/닉네임이 먼저 저장되는 경우
- 초기 아이디어
    - 중복체크 API가 있으므로 회원가입 API 요청 시 409 에러를 반환하는 것이 사용자 입장에서 부자연스럽겠다는 생각이 듦
    - 따라서 중복 체크 API 호출 시 이메일/닉네임을 일정 시간 동안 `예약` 처리하는 방법 고민
    - 예약된 동안 다른 사용자가 동일한 값으로 가입 시도하면 중복 에러 반환
    - 예약 정보는 메모리 맵이나 Redis에 저장하고, 익명 쿠키로 클라이언트를 구분하는 방식 고려
        - 예약 등록 후 30분이 지나면 해당 정보 삭제 (예약 취소)
- 문제점
    - 누군가 조합 가능한 대량의 이메일/닉네임을 악의적으로 대량 요청해 모든 예약이 다 참 -> 일정 시간 동안 정상적인 가입 불가
    - 예약 관리 위한 복잡성 및 성능 이슈 예상
        - 회원가입 시 데이터베이스뿐만 아니라 예약 정보까지 이중으로 확인
        - 등록된 지 30분 지난 예약을 삭제하기 위한 로직 필요
   - 이메일/닉네임이 애초에 중복이 자주 발생하며 중복을 막기 위해 그렇게까지 할 필요가 있는가?
       - 이메일은 이미 다른 곳에서 사용하던 것을 쓸 테니 중복 가능성이 적다고 봄
       - 닉네임은 중복될 수 있지만 서버 메모리에 올려서 관리해야 할 만큼 중복성 체크가 필요한지 의문
           - 예약 관리 위한 리소스에 비해 사용자가 불편함을 감수하는 게 오히려 더 나을지도
       - 이메일/닉네임 중복 체크 후 가입까지 보통 텀이 짧을 것으로 예상 -> 실제 회원가입 요청 시 중복 위험 적겠다
           - 프로필 사진 선택에 시간이 소요될 수 있지만, UI 상으로 프로필 사진이 맨 위에 있으므로 프로필 사진을 먼저 고른 후 나머지 텍스트를 빠르게 입력해 가입 완료할 것으로 예상함
- 결론
    - 회원가입 API에서도 이메일/닉네임 중복 체크 진행 후 409 에러 반환